### PR TITLE
Option : logrotate-wizard can now manage_cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Logrotate-wizard
 Logrotate-wizard installs a given version of logrotate from source. The
 installation is lightweight and do not overwrite an existing one.
 
+Logrotate-wizard is *not a package manager*, and thus does not manage the
+dependencies and or install/update triggers.
+
+It should be used for debug purposes or hotfix purposes only. A legit use would
+be the need to use a version of logrotate before it is packaged for your
+distributions. It will break and do nasty things if you don't pay attention.
+
+Use official packages back as soon as possible. Wizardry is dangerous, dont use
+it too often
+
 Requirements
 ------------
 
@@ -13,8 +23,19 @@ contribute for other types of linux distributions.
 Role Variables
 --------------
 
-The only variable you need is `logrotate_version`. The role will get the given
+The only compulsory variable is `logrotate_version`. The role will get the given
 version to build from git repository tagged with`logrotate_version`.
+It is not set by default on purpose so you pick carefully the version you want
+to install. You can play this role several times with different
+`logrotate_version` values.
+
+You can tell `logrotate-wizard` to manage your anacron files (located in
+/etc/cron.daily /etc/cron.monthly etc.)
+
+Those cron scripts are run by /etc/crontab, which in turns use `run-parts` on
+each directory. The default packaged files for cron use an absolute path to call
+`logrotate`. If you need your cron to call the `logrotate_version` of your
+choice, please set `manage_cron` to true (default is false)
 
 Example Playbook
 ----------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,3 +47,9 @@
     state: link
     path: /usr/local/sbin/logrotate
     src: "/usr/local/sbin/logrotate_builds/logrotate-{{ logrotate_version }}"
+
+- name: Manage logrotate files in anacron directories
+  include: manage_logrotate_files_in_anacron_directories.yml
+  when: manage_cron
+  tags: cron
+

--- a/tasks/manage_logrotate_files_in_anacron_directories.yml
+++ b/tasks/manage_logrotate_files_in_anacron_directories.yml
@@ -1,0 +1,28 @@
+- name: Check if logrotate package is already installed
+  shell: "[[ `dpkg -s logrotate | grep 'Status'` =~ installed ]]"
+  register: logrotate_pkg_presence_test_command
+  ignore_errors: true
+  no_log: true
+
+- set_fact:
+    logrotate_pkg_presence: "{{ logrotate_pkg_presence_test_command.rc == 0 }}"
+
+- name: Retrieve anacron dirs
+  shell: 'ls /etc/cron.*ly -d'
+  register: anacron_directories_test_command
+  ignore_errors: true
+  no_log: true
+
+- set_fact:
+    anacron_directories: "{{ anacron_directories_test_command.stdout_lines }}"
+  when: "{{ anacron_directories_test_command.rc == 0 }}"
+
+- set_fact:
+    anacron_directories: "[]"
+  when: "{{ anacron_directories_test_command.rc != 0 }}"
+
+- name: Manage logrotate file for given anacron directory
+  include: manage_logrotate_files_in_anacron_directory.yml
+  with_items: "{{ anacron_directories }}"
+  loop_control:
+    loop_var: anacron_directory

--- a/tasks/manage_logrotate_files_in_anacron_directory.yml
+++ b/tasks/manage_logrotate_files_in_anacron_directory.yml
@@ -1,0 +1,31 @@
+- name: Check if anacron_directory has logrotate file managed by pkg manager
+  shell: "[ -f {{ anacron_directory }}/logrotate ]"
+  register: managed_by_pkg_manager_test_command
+  ignore_errors: true
+  no_log: true
+
+- set_fact:
+    managed_by_pkg_manager: "{{ managed_by_pkg_manager_test_command.rc == 0 }}"
+
+- name: Duplicate logrotate file managed by pkg manager
+  copy:
+    src:  "{{ anacron_directory }}/logrotate"
+    dest: "{{ anacron_directory }}/logrotate_managed_by_wizard"
+    mode: preserve
+    remote_src: true
+  when: managed_by_pkg_manager
+
+- name: Comment logrotate file managed by pkg manager
+  shell: "sed -i 's/^/#/g' {{ anacron_directory }}/logrotate"
+  when: managed_by_pkg_manager
+
+- name: Rename logrotate file managed by pkg manager for clarity
+  shell: "mv {{ anacron_directory }}/logrotate {{ anacron_directory }}/logrotate_managed_by_pkg_manager"
+  when: managed_by_pkg_manager
+
+- name: Replace occurences of packaged logrotate into
+  replace:
+    path: "{{ anacron_directory }}/logrotate_managed_by_wizard"
+    regexp:  '[^\s]+logrotate\s'
+    replace: '/usr/local/sbin/logrotate '
+  when: managed_by_pkg_manager

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for logrotate-wizard
+manage_cron: false


### PR DESCRIPTION
manage_cron option backups package managed cron script, and sets a patched version of it in place

patched version is a copy pasta in which occurences of package managed path for logrotate is being replaced with our pathing